### PR TITLE
Collect backtest bets for reliability metrics

### DIFF
--- a/core/calibration_runner.py
+++ b/core/calibration_runner.py
@@ -316,7 +316,7 @@ class CalibrationRunner:
         best_sharpe = -999
         
         for threshold in thresholds:
-            metrics = self._evaluate_threshold(market_data, threshold, market_type)
+            metrics, _ = self._evaluate_threshold(market_data, threshold, market_type)
             
             # Require minimum 100 bets and 45% hit rate
             if metrics.total_bets >= 100 and metrics.hit_rate >= 0.45:
@@ -333,7 +333,7 @@ class CalibrationRunner:
         market_data: List[Dict[str, Any]],
         threshold: float,
         market_type: str
-    ) -> CalibrationMetrics:
+    ) -> Tuple[CalibrationMetrics, List[Dict[str, Any]]]:
         """
         Evaluate a specific edge threshold.
         
@@ -343,7 +343,7 @@ class CalibrationRunner:
             market_type: Market type
             
         Returns:
-            Calibration metrics
+            Tuple of (calibration metrics, bet records)
         """
         bets = []
         
@@ -412,7 +412,7 @@ class CalibrationRunner:
                         'profit': profit
                     })
         
-        return self._calculate_metrics(bets)
+        return self._calculate_metrics(bets), bets
     
     def _american_to_prob(self, american_odds: int) -> float:
         """
@@ -589,7 +589,8 @@ class CalibrationRunner:
             market_data = [r for r in test_calibration if r['market_type'] == market_type]
             threshold = edge_thresholds[market_type]
             
-            metrics = self._evaluate_threshold(market_data, threshold, market_type)
+            metrics, bets = self._evaluate_threshold(market_data, threshold, market_type)
+            all_bets.extend(bets)
             
             logger.info(f"\n{market_type.upper()} Results:")
             logger.info(f"  Threshold: {threshold:.3f}")


### PR DESCRIPTION
### Motivation

- Ensure reliability bins and aggregate performance metrics are computed from the actual bet records produced per-market during the test phase.
- `_evaluate_threshold()` previously returned only `CalibrationMetrics`, so `run_backtest()` could not aggregate raw bet records across markets.
- Collecting bets enables accurate reliability calibration and unified metric aggregation across `moneyline`, `spread`, and `total` markets.
- This supports generation of calibration packs that include empirical reliability bins and end-to-end test statistics.

### Description

- Change `_evaluate_threshold()` to return `Tuple[CalibrationMetrics, List[Dict[str, Any]]]` so bet records are returned alongside metrics.
- Update `tune_edge_thresholds()` to unpack `metrics, _` when running the grid search to keep previous behavior while ignoring bets there.
- Update `run_backtest()` to unpack `metrics, bets` for each market and extend a single `all_bets` list that feeds `calculate_reliability_bins()` and is used by `_calculate_metrics()` for aggregation.
- Keep logging of per-market `metrics` unchanged while now collecting per-market `bets` for calibration and aggregation.

### Testing

- No automated tests were executed as part of this change.
- Static type hints were added/updated via function signature changes and existing code paths were adapted accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be05c948883238aab9f627aeb0ebb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Backtest data collection now captures and tracks bet records throughout the evaluation process, enabling more comprehensive reliability analysis of trading performance across all market types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->