### PR TITLE
Add edge correlation diagnostics to calibration backtests

### DIFF
--- a/core/calibration_diagnostics.py
+++ b/core/calibration_diagnostics.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+
+def _rankdata(values: np.ndarray) -> np.ndarray:
+    order = np.argsort(values, kind="mergesort")
+    ranks = np.empty(len(values), dtype=float)
+    sorted_vals = values[order]
+    index = 0
+    while index < len(values):
+        next_index = index + 1
+        while next_index < len(values) and sorted_vals[next_index] == sorted_vals[index]:
+            next_index += 1
+        average_rank = (index + 1 + next_index) / 2.0
+        ranks[order[index:next_index]] = average_rank
+        index = next_index
+    return ranks
+
+
+def _spearman_correlation(x: np.ndarray, y: np.ndarray) -> Optional[float]:
+    if len(x) < 2 or len(y) < 2:
+        return None
+    x_rank = _rankdata(x)
+    y_rank = _rankdata(y)
+    if np.std(x_rank) == 0 or np.std(y_rank) == 0:
+        return None
+    return float(np.corrcoef(x_rank, y_rank)[0, 1])
+
+
+def analyze_edge_correlation(bets: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not bets:
+        return None
+
+    edges = np.array([bet.get("edge", 0.0) for bet in bets], dtype=float)
+    outcomes = np.array([bet.get("outcome", 0.0) for bet in bets], dtype=float)
+    implied_probs = np.array([bet.get("prob", 0.0) for bet in bets], dtype=float)
+
+    spearman = _spearman_correlation(edges, outcomes)
+    mean_implied = float(np.mean(implied_probs)) if len(implied_probs) else 0.0
+    mean_outcome = float(np.mean(outcomes)) if len(outcomes) else 0.0
+    bias = mean_implied - mean_outcome
+
+    if bias > 0.02:
+        bias_label = "overconfidence"
+    elif bias < -0.02:
+        bias_label = "underconfidence"
+    else:
+        bias_label = "well_calibrated"
+
+    return {
+        "bet_count": int(len(bets)),
+        "spearman_correlation": spearman,
+        "mean_implied_prob": mean_implied,
+        "mean_outcome": mean_outcome,
+        "bias": float(bias),
+        "bias_label": bias_label,
+    }


### PR DESCRIPTION
### Motivation
- Provide automated calibration diagnostics that measure correlation between edge size and realized outcomes to detect model signal quality.
- Surface systematic bias (overconfidence vs underconfidence) in implied probabilities to guide probability transforms and calibration.
- Make diagnostics available alongside reliability bins and metrics so they can be saved in the calibration pack.

### Description
- Add `core/calibration_diagnostics.py` implementing `analyze_edge_correlation()` which computes a Spearman correlation, mean implied probability, mean outcome, bias, and a bias label.
- Refactor bet generation by splitting `_evaluate_threshold()` into `self._generate_bets()` (returns bet records) and `_evaluate_threshold()` (wraps metrics), and aggregate bets into `all_bets` during test evaluation.
- Integrate `analyze_edge_correlation(all_bets)` into `CalibrationRunner.run_backtest()` with logging of the Spearman score and bias, and include diagnostics in the `CalibrationPack` output under the `diagnostics` field.
- Update function signatures and return values where necessary to propagate the `diagnostics` object through `run_backtest()` and `generate_calibration_pack()` and ensure `CalibrationPack` dataclass can store `diagnostics`.

### Testing
- No automated tests were executed as part of this change.
- The change was compiled/committed locally (files added/modified: `core/calibration_diagnostics.py`, `core/calibration_runner.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be061d8ac8323965db278a75b1c71)